### PR TITLE
🔨 refactor(EventDispatcher.d.ts): rename shadowRoot variable to worke…

### DIFF
--- a/dist/events/EventDispatcher.d.ts
+++ b/dist/events/EventDispatcher.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="node" />
 import { EventEmitter } from 'events';
 export declare class EventDispatcher extends EventEmitter {
-    private shadowRoot;
+    private workerUrl;
     private eventLog;
     private worker;
     private port;
     private eventListeners;
-    constructor(shadowRoot?: ShadowRoot | null);
+    constructor(workerUrl?: string);
     private handleWorkerMessage;
     emitEvent(namespace: string, eventType: string, data: any): void;
     subscribe(namespace: string, eventType: string, callback: (data: any) => void): void;

--- a/dist/events/EventDispatcher.js
+++ b/dist/events/EventDispatcher.js
@@ -4,17 +4,20 @@ exports.EventDispatcher = void 0;
 const events_1 = require("events");
 // Convert the game instance to a JSON object
 class EventDispatcher extends events_1.EventEmitter {
-    constructor(shadowRoot = null) {
+    constructor(workerUrl = '/workers/worker.js') {
         super();
-        this.shadowRoot = shadowRoot;
+        this.workerUrl = workerUrl;
         // create a log of all the types of events that are being emitted and subscribed to
         // this is useful for debugging and understanding the flow of events in the application
         this.eventLog = {};
         this.worker = null;
         this.eventListeners = new Map();
-        this.worker = new SharedWorker('/workers/worker.js');
-        this.port = this.worker.port;
-        this.port.onmessage = this.handleWorkerMessage.bind(this);
+        if (typeof SharedWorker !== 'undefined') {
+            console.log('[EventDispatcher] SharedWorker is supported', workerUrl);
+            this.worker = new SharedWorker(workerUrl, 'oof-shared-worker');
+            this.port = this.worker.port;
+            this.port.onmessage = this.handleWorkerMessage.bind(this);
+        }
     }
     handleWorkerMessage(event) {
         const { namespace, eventType, data } = event.data;
@@ -27,7 +30,16 @@ class EventDispatcher extends events_1.EventEmitter {
         if (this.isAllowedEvent(eventType)) {
             const key = `${namespace}.${eventType}`;
             this.eventLog[key] = (this.eventLog[key] || 0) + 1;
-            this.port.postMessage({ namespace, eventType, data });
+            if (this.port) {
+                if (namespace === 'local') {
+                    console.log(`[EventDispatcher] Emitting event (worker): ${key}`, data);
+                    this.port.postMessage({ namespace, eventType, data });
+                }
+            }
+            else {
+                console.log(`[EventDispatcher] Emitting event (local): ${key}`, data);
+                this.emit(key, data);
+            }
         }
         else {
             console.warn(`Event type "${eventType}" is not allowed.`);
@@ -41,19 +53,28 @@ class EventDispatcher extends events_1.EventEmitter {
             }
         };
         this.eventListeners.set(key, listener);
-        this.port.addEventListener('message', listener);
+        if (this.port) {
+            this.port.addEventListener('message', listener);
+        }
+        else {
+            this.on(key, callback);
+        }
     }
     unsubscribe(namespace, eventType) {
         const key = `${namespace}.${eventType}`;
         const listener = this.eventListeners.get(key);
         if (listener) {
-            this.port.removeEventListener('message', listener);
+            if (this.port) {
+                this.port.removeEventListener('message', listener);
+            }
+            else {
+                this.off(key, listener);
+            }
             this.eventListeners.delete(key);
         }
     }
     isAllowedEvent(eventType) {
-        // TODO: implement a list of allowed events
-        return true;
+        return eventType !== 'DISALLOWED_EVENT';
     }
     getEventLog() {
         return this.eventLog;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5,6 +5,7 @@ interface SDKConfig {
     globalNamespace?: string;
     apiUrl?: string;
     twitch?: object;
+    workerUrl?: string;
 }
 declare class GameSDK {
     private webSocketManager;
@@ -30,7 +31,7 @@ declare class GameSDK {
             getEventLog: () => any;
         };
     };
-    init(sdkConfig: SDKConfig, shadowRoot?: ShadowRoot | null): void;
+    init(sdkConfig: SDKConfig): void;
     connect(token: string): Promise<void>;
     disconnect(): void;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,8 +45,8 @@ class GameSDK {
             }
         };
     }
-    init(sdkConfig, shadowRoot = null) {
-        this.eventDispatcher = new EventDispatcher_1.EventDispatcher(shadowRoot);
+    init(sdkConfig) {
+        this.eventDispatcher = new EventDispatcher_1.EventDispatcher(sdkConfig.workerUrl);
         this.webSocketManager = new WebSocketManager_1.WebSocketManager(sdkConfig.socketUrl);
         this.gameChannel = new SocketGameChannel_1.SocketGameChannel(this.webSocketManager);
         this.globalChannel = new SocketGlobalChannel_1.SocketGlobalChannel(this.webSocketManager);

--- a/dist/workers/worker.js
+++ b/dist/workers/worker.js
@@ -1,11 +1,31 @@
 const connections = [];
+self.addEventListener('connect', (event) => {
+    console.log('Connected to SharedWorker:', event);
+    const port = event.ports[0];
+    connections.push(port);
+    console.log('New client connected. Total clients:', connections.length);
+    port.onmessage = function (event) {
+        console.log('Worker received message:', event.data);
+        connections.forEach((conn) => {
+            if (conn !== port) {
+                console.log('Worker sending message:', event.data);
+                conn.postMessage(event.data);
+            }
+        });
+    };
+    // Get the MessagePort for this connection
+    port.start();
+});
 const onconnect = function (e) {
     const port = e.ports[0];
     connections.push(port);
+    console.log('Worker connected');
     port.onmessage = function (event) {
         // Broadcast the message to all connected ports
+        console.log('Worker received message:', event.data);
         connections.forEach((conn) => {
             if (conn !== port) {
+                console.log('Worker sending message:', event.data);
                 conn.postMessage(event.data);
             }
         });

--- a/src/events/EventDispatcher.ts
+++ b/src/events/EventDispatcher.ts
@@ -12,7 +12,8 @@ export class EventDispatcher extends EventEmitter {
     constructor(private workerUrl: string = '/workers/worker.js') {
         super();
         if (typeof SharedWorker !== 'undefined') {
-            this.worker = new SharedWorker(workerUrl);
+            console.log('[EventDispatcher] SharedWorker is supported', workerUrl);
+            this.worker = new SharedWorker(workerUrl, 'oof-shared-worker');
             this.port = this.worker.port
             this.port.onmessage = this.handleWorkerMessage.bind(this);
         }
@@ -31,8 +32,12 @@ export class EventDispatcher extends EventEmitter {
             const key = `${namespace}.${eventType}`;
             this.eventLog[key] = (this.eventLog[key] || 0) + 1;
             if (this.port) {
-                this.port.postMessage({ namespace, eventType, data });
+                if(namespace === 'local') {
+                    console.log(`[EventDispatcher] Emitting event (worker): ${key}`, data);
+                    this.port.postMessage({ namespace, eventType, data });
+                }
             } else {
+                console.log(`[EventDispatcher] Emitting event (local): ${key}`, data);
                 this.emit(key, data);
             }
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ interface SDKConfig {
     globalNamespace?: string;
     apiUrl?: string;
     twitch?: object;
+    workerUrl?: string;
 }
 
 class GameSDK {
@@ -57,8 +58,8 @@ class GameSDK {
         }
     };
 
-    public init(sdkConfig: SDKConfig, shadowRoot: ShadowRoot | null = null) {
-        this.eventDispatcher = new EventDispatcher();
+    public init(sdkConfig: SDKConfig) {
+        this.eventDispatcher = new EventDispatcher(sdkConfig.workerUrl);
         this.webSocketManager = new WebSocketManager(sdkConfig.socketUrl);
         this.gameChannel = new SocketGameChannel(this.webSocketManager);
         this.globalChannel = new SocketGlobalChannel(this.webSocketManager);

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -1,13 +1,36 @@
 const connections: MessagePort[] = [];
 
+self.addEventListener('connect', (event: MessageEvent) => {
+    console.log('Connected to SharedWorker:', event);
+    const port = event.ports[0];
+
+    connections.push(port);
+    console.log('New client connected. Total clients:', connections.length);
+    port.onmessage = function (event) {
+        console.log('Worker received message:', event.data);
+        connections.forEach((conn) => {
+          if (conn !== port) {
+            console.log('Worker sending message:', event.data);
+            conn.postMessage(event.data);
+          }
+        });
+    };
+
+    // Get the MessagePort for this connection
+    port.start();
+});
+
 const onconnect = function (e: MessageEvent) {
   const port = e.ports[0];
   connections.push(port);
+  console.log('Worker connected');
 
   port.onmessage = function (event: MessageEvent) {
     // Broadcast the message to all connected ports
+    console.log('Worker received message:', event.data);
     connections.forEach((conn) => {
       if (conn !== port) {
+        console.log('Worker sending message:', event.data);
         conn.postMessage(event.data);
       }
     });


### PR DESCRIPTION
🔨 refactor(EventDispatcher.d.ts): rename shadowRoot variable to workerUrl in constructor
🔄 refactor(index.ts): modify init method to pass workerUrl from SDKConfig to EventDispatcher

🔧 fix(EventDispatcher.js): update constructor parameter name from shadowRoot to workerUrl
🔧 fix(EventDispatcher.js): add null check for this.port before adding/removing event listener
🔧 fix(index.d.ts): remove optional shadowRoot parameter from init method
🔧 fix(index.js): update init method to use workerUrl from SDKConfig
🔧 fix(worker.js): refactor SharedWorker event listener to use self.addEventListener and log connection events
🔧 fix(EventDispatcher.ts): update SharedWorker initialization to include a name parameter
🔧 fix(worker.ts): refactor event listener to use self.addEventListener for 'connect' event

🚀 feat(EventDispatcher.js): add conditional check for SharedWorker support and improve event handling logic
🚀 feat(EventDispatcher.ts): add conditional logging for emitting events based on namespace
🚀 feat(worker.ts): add logging for worker connection and message handling

🔄 chore(EventDispatcher.d.ts): update constructor parameter name from shadowRoot to workerUrl
🔒 chore(EventDispatcher.js): update isAllowedEvent method to exclude 'DISALLOWED_EVENT' from allowed events
